### PR TITLE
early access

### DIFF
--- a/script/SM/nenen88.py
+++ b/script/SM/nenen88.py
@@ -79,8 +79,8 @@ def strip_(url):
 
             data = response.json()
 
-            early_access = data.get("earlyAccessConfig")
-            if early_access and early_access.get("chargeForDownload", False):
+            early_access = data.get("earlyAccessEndsAt", None)
+            if early_access:
                 model_id = data.get("modelId")
                 version_id = data.get("id")
                 

--- a/script/SM/pantat88.py
+++ b/script/SM/pantat88.py
@@ -82,8 +82,8 @@ def strip_(url):
 
             data = response.json()
 
-            early_access = data.get("earlyAccessConfig")
-            if early_access and early_access.get("chargeForDownload", False):
+            early_access = data.get("earlyAccessEndsAt", None)
+            if early_access:
                 model_id = data.get("modelId")
                 version_id = data.get("id")
                 


### PR DESCRIPTION
- change the method of checking the paid model (by expiration date).

_When specifying a model version, even when it is not paid, the download does not start with a message that the model must be purchased._

By Example (NSFW):
`https://civitai.com/models/166609?modelVersionId=992946`